### PR TITLE
Add already in network join event

### DIFF
--- a/lib/components/controller.js
+++ b/lib/components/controller.js
@@ -537,7 +537,8 @@ Controller.prototype.endDeviceAnnceHdlr = function (data) {
 
     if (dev && dev.status === 'online'){ //Device has already joined, do next item in queue
         console.log('device already in network');
-        if (self._joinQueue.length) {
+	    self.getShepherd().emit('joining', {type: 'already_in_network', ieeeAddr: data.ieeeaddr});
+	    if (self._joinQueue.length) {
             var next = self._joinQueue.shift();
 
             if (next){


### PR DESCRIPTION
This will be used in the pairing wizard to show an error message when a
user tries to pair a device that is already in the network.