### PR TITLE
Fix for device_already_paired bug

### DIFF
--- a/lib/components/controller.js
+++ b/lib/components/controller.js
@@ -570,8 +570,6 @@ Controller.prototype.endDeviceAnnceHdlr = function (data) {
     }, 30000);
 
     this.once(joinEvent, function () {
-        self._spinLock = false;
-
         if (joinTimeout) {
             clearTimeout(joinTimeout);
             joinTimeout = null;
@@ -580,10 +578,15 @@ Controller.prototype.endDeviceAnnceHdlr = function (data) {
         if (self._joinQueue.length) {
             var next = self._joinQueue.shift();
 
-            if (next)
+            if (next){
                 setImmediate(function () {
                     next.func();
                 });
+            }else{
+                self._spinLock = false;
+            }
+        }else{
+            self._spinLock = false;
         }
     });
 
@@ -594,7 +597,17 @@ Controller.prototype.endDeviceAnnceHdlr = function (data) {
     }).fail(function () {
         return self.simpleDescReq(data.nwkaddr, data.ieeeaddr);
     }).then(function (devInfo) {
-        self.emit('ZDO:devIncoming', devInfo);
+        // Now that we have the simple description of the device clear joinTimeout
+        if (joinTimeout) {
+            clearTimeout(joinTimeout);
+            joinTimeout = null;
+        }
+
+        // Defer a promise to wait for the controller to complete the ZDO:devIncoming event!
+        var processIncoming = Q.defer();
+        self.emit('ZDO:devIncoming', devInfo, processIncoming.resolve, processIncoming.reject);
+        return processIncoming.promise;
+    }).then(function () {
         self.emit(joinEvent, '__timeout__');
     }).fail(function () {
         self.getShepherd().emit('error', 'Cannot get the Node Descriptor of the Device: ' + data.ieeeaddr);

--- a/lib/components/event_handlers.js
+++ b/lib/components/event_handlers.js
@@ -79,7 +79,7 @@ handlers.resetInd = function (msg) {
 	}).done();
 };
 
-handlers.devIncoming = function (devInfo) {
+handlers.devIncoming = function (devInfo, resolve) {
 	// devInfo: { type, ieeeAddr, nwkAddr, manufId, epList, endpoints: [ simpleDesc, ... ] }
 	var self = this,
 		dev = this._findDevByAddr(devInfo.ieeeAddr),
@@ -100,7 +100,7 @@ handlers.devIncoming = function (devInfo) {
 		});
 	}
 
-	Q.fcall(function () {
+	var processDev = Q.fcall(function () {
 		if (dev) {
 			dev.update(devInfo);
 			dev.update({ status: 'online', joinTime: Math.floor(Date.now()/1000) });
@@ -252,7 +252,12 @@ handlers.devIncoming = function (devInfo) {
 		}
 	}).fail(function (err) {
 		self.emit('error', err);
-	}).done();
+	});
+
+	if(typeof resolve === 'function'){
+		resolve(processDev);
+	}
+	processDev.done();
 };
 
 handlers.leaveInd = function (msg) {


### PR DESCRIPTION
Fixed bug causing _spinLock to release to early while pairing resulting in a race condition that would throw a "device already paired" error when a new broadcast is received from the device that is still being interviewed to complete pairing.