### PR TITLE
Remove unused delegators

### DIFF
--- a/lib/initializers/init_controller.js
+++ b/lib/initializers/init_controller.js
@@ -61,8 +61,7 @@ init._startupCoord = function (controller) {
 init._registerDelegators = function (controller, netInfo) {
     var coord = controller.getCoord(),
         dlgInfos =  [
-            { profId: 0x0101, epId: 1 }, { profId: 0x0104, epId: 2 }, { profId: 0x0105, epId: 3 },
-            { profId: 0x0107, epId: 4 }, { profId: 0x0108, epId: 5 }, { profId: 0x0109, epId: 6 }
+            { profId: 0x0104, epId: 1 }
         ];
 
     return controller.simpleDescReq(0, netInfo.ieeeAddr).then(function (devInfo) {


### PR DESCRIPTION
This is a workaround for Xiaomi devices which are hardcoded reporting on endpoint 1 and therefore expecting profile 0x0104 (HA). Tested migration with several devices installed (Ikea bulbs and rotating dimmer, KaKu bulbs, Osram Plug, some Xiaomi devices and Philips Hue motion sensor). No issues discovered.