### PR TITLE
Reject endpoint.read promise when failed

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -630,6 +630,8 @@ ZShepherd.prototype._attachZclMethods = function (ep) {
 					deferred.resolve(rec.attrData);
 				else
 					deferred.reject(new Error('request unsuccess: ' + rec.status));
+			}).catch(function(err) {
+				deferred.reject(err);
 			});
 
 			return deferred.promise.nodeify(callback);


### PR DESCRIPTION
This could cause the zigbee command queue to block as the read promises where never resolved/rejected.

Very likely fixes: https://github.com/athombv/homey/issues/1936