### PR TITLE
Return event emitter in generateMap callback instead of result

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -483,6 +483,7 @@ ZShepherd.prototype.generateMap = function(opts, callback){
 	var info = this.info();
 	var nodes = {};
 	var links = [];
+	var events = new EventEmitter();
 	this.recursiveDeviceLQI(info.net.ieeeAddr, nodes, links, function() {
 		debug.shepherd('recursive LQI done');
 		this.createLinkMap(nodes, links);
@@ -490,8 +491,10 @@ ZShepherd.prototype.generateMap = function(opts, callback){
 		debug.shepherd(nodes);
 		debug.shepherd('links')
 		debug.shepherd(links);
+		events.emit('done', links);
 		return callback(null, links)
 	}.bind(this));
+	return callback(null, events);
 };
 
 ZShepherd.prototype.createLinkMap = function(nodes, links) {
@@ -732,7 +735,7 @@ ZShepherd.prototype._foundation = function (srcEp, dstEp, cId, cmd, zclData, cfg
 		cmdString = cmdString ? cmdString.key : cmd;
 
 		if (cmdString === 'read')
-			self._updateFinalizer(dstEp, cId, msg.payload);
+				self._updateFinalizer(dstEp, cId, msg.payload);
 		else if (cmdString === 'write' || cmdString === 'writeUndiv' || cmdString === 'writeNoRsp')
 			self._updateFinalizer(dstEp, cId);
 


### PR DESCRIPTION
The event emitter is then used to emit a `done` event when the link results are fetched asynchronously (which can take a long time especially with many offline/battery nodes). The callback is called immediately (could have been a return value, but did not want to break consistency here).