### PR TITLE
Retry the zclFunctional command once after it failed

### DIFF
--- a/lib/shepherd.js
+++ b/lib/shepherd.js
@@ -767,6 +767,11 @@ ZShepherd.prototype._functional = function (srcEp, dstEp, cId, cmd, zclData, cfg
 	return this.af.zclFunctional(srcEp, dstEp, cId, cmd, zclData, cfg).then(function (msg) {
 		self._updateFinalizer(dstEp, cId);
 		return msg.payload;
+	}).fail(function() {
+		return self.af.zclFunctional(srcEp, dstEp, cId, cmd, zclData, cfg).then(function (msg) {
+			self._updateFinalizer(dstEp, cId);
+			return msg.payload;
+		});
 	}).nodeify(callback);
 };
 


### PR DESCRIPTION
This might improve the reliability of controlling ZigBee devices, as mentioned in these issues:
- https://github.com/athombv/homey/issues/1956
- https://github.com/athombv/homey/issues/1859

Please merge this to production.